### PR TITLE
🚸 feat(create-drupal-decoupled) Add Remix error boundary

### DIFF
--- a/packages/create-drupal-decoupled/src/templates/remix-graphql/$.tsx
+++ b/packages/create-drupal-decoupled/src/templates/remix-graphql/$.tsx
@@ -1,13 +1,19 @@
+import {
+  isRouteErrorResponse,
+  useRouteError,
+  useLoaderData,
+} from '@remix-run/react'
 import { LoaderFunctionArgs } from '@remix-run/node'
-import { useLoaderData } from '@remix-run/react'
 import { gql } from 'urql'
 
 import { getDrupalClient } from '~/utils/drupal-client.server'
 
+const GET_DRUPAL_CONTENT_ERROR = 'Error fetching data from Drupal'
+
 export const loader = async ({ params }: LoaderFunctionArgs) => {
   const path = params['*']
   const drupalClient = await getDrupalClient()
-  const { data } = await drupalClient.query(
+  const { data, error } = await drupalClient.query(
     gql`
       query getNodeArticleByPath($path: String!) {
         route(path: $path) {
@@ -30,6 +36,10 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
     }
   )
 
+  if (error) {
+    throw new Response(GET_DRUPAL_CONTENT_ERROR, { status: 500 })
+  }
+
   return { data }
 }
 
@@ -41,4 +51,23 @@ export default function Index() {
       <div dangerouslySetInnerHTML={{ __html: data.route.entity.body.value }} />
     </div>
   )
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError()
+  if (isRouteErrorResponse(error)) {
+    if (error.data === GET_DRUPAL_CONTENT_ERROR) {
+      return (
+        <div className='p-4 text-center'>
+          <p>There was an error fetching the Drupal content</p>
+          <p>
+            Hint: Make sure that the query in the loader function is correct and
+            the fields are enabled in the GraphQL Compose module
+          </p>
+        </div>
+      )
+    }
+    return <p>Uh oh, something went wrong</p>
+  }
+  return <p>Uh oh, something went wrong</p>
 }


### PR DESCRIPTION
# What this PR does?
- Throw a response error when the query has an error
- When that happens, the error is caught by the remix error boundary