### PR TITLE
✨ feat(packages): Bump minor version create-drupal-decoupled

### DIFF
--- a/.changeset/fuzzy-crabs-greet.md
+++ b/.changeset/fuzzy-crabs-greet.md
@@ -1,0 +1,5 @@
+---
+"@octahedroid/create-drupal-decoupled": minor
+---
+
+Start from minor version


### PR DESCRIPTION
We don't have a 0.0.1 published, so let's jump right to 0.1.0 for the create-drupal-decoupled package.