### PR TITLE
♻️ feat: children for button icon

### DIFF
--- a/starters/next/components/primitives/Button/Button.stories.tsx
+++ b/starters/next/components/primitives/Button/Button.stories.tsx
@@ -8,9 +8,9 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   args: {
     text: 'Default',
-    icon: undefined,
     variant: 'default',
     size: 'default',
+    children: undefined,
   },
   argTypes: {
     variant: {
@@ -27,11 +27,6 @@ const meta: Meta<typeof Button> = {
     size: {
       control: 'select',
       options: ['default', 'sm', 'lg', 'icon'],
-    },
-    icon: {
-      table: {
-        disable: true,
-      },
     },
   },
 }
@@ -78,13 +73,14 @@ export const Large: Story = {
 
 export const WithIcon: Story = {
   args: {
-    icon: ChevronRight,
+    text: 'With Icon',
+    children: <ChevronRight />,
   },
 }
 
 export const IconOnly: Story = {
   args: {
     text: '',
-    icon: ChevronRight,
+    children: <ChevronRight />,
   },
 }

--- a/starters/next/components/primitives/Button/Button.tsx
+++ b/starters/next/components/primitives/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { LucideIcon } from 'lucide-react'
+import { ReactNode } from 'react'
 import { Link } from '@/components/primitives'
 import {
   Button as ShadcnButton,
@@ -9,16 +9,17 @@ export interface ButtonProps extends Omit<ShadcnButtonProps, 'asChild'> {
   href: string
   internal?: boolean
   text: string
-  icon?: LucideIcon
+  children?: ReactNode
 }
 
-export const Button = ({ href, text, internal, ...props }: ButtonProps) => {
-  const content = (
-    <>
-      {text}
-      {props.icon && <props.icon className="ml-2 h-4 w-4" />}
-    </>
-  )
+export const Button = ({
+  href,
+  text,
+  internal,
+  children,
+  ...props
+}: ButtonProps) => {
+  const content = children ? (text ? <>{text} {children}</> : children) : (text && <>{text}</>)
   if (href) {
     return (
       <Link internal={internal} href={href}>

--- a/starters/next/components/primitives/TeaserCard/TeaserCard.tsx
+++ b/starters/next/components/primitives/TeaserCard/TeaserCard.tsx
@@ -61,13 +61,9 @@ export const TeaserCard = ({
         <p className="flex-grow text-sm text-muted-foreground">{summary}</p>
         {details && (
           <div className="pt-2">
-            <Button
-              variant="link"
-              className="p-0"
-              icon={ChevronRight}
-              internal
-              {...details}
-            />
+            <Button variant="link" className="p-0" internal {...details}>
+              <ChevronRight className="ml-2 h-4 w-4" />
+            </Button>
           </div>
         )}
       </div>

--- a/starters/remix/app/components/primitives/Button/Button.stories.tsx
+++ b/starters/remix/app/components/primitives/Button/Button.stories.tsx
@@ -8,9 +8,9 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   args: {
     text: 'Default',
-    icon: undefined,
     variant: 'default',
     size: 'default',
+    children: undefined,
   },
   argTypes: {
     variant: {
@@ -27,11 +27,6 @@ const meta: Meta<typeof Button> = {
     size: {
       control: 'select',
       options: ['default', 'sm', 'lg', 'icon'],
-    },
-    icon: {
-      table: {
-        disable: true,
-      },
     },
   },
 }
@@ -78,13 +73,14 @@ export const Large: Story = {
 
 export const WithIcon: Story = {
   args: {
-    icon: ChevronRight,
+    text: 'With Icon',
+    children: <ChevronRight />,
   },
 }
 
 export const IconOnly: Story = {
   args: {
     text: '',
-    icon: ChevronRight,
+    children: <ChevronRight />,
   },
 }

--- a/starters/remix/app/components/primitives/Button/Button.tsx
+++ b/starters/remix/app/components/primitives/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { LucideIcon } from 'lucide-react'
+import { ReactNode } from 'react'
 import { Link } from '~/components/primitives'
 import {
   Button as ShadcnButton,
@@ -9,16 +9,17 @@ export interface ButtonProps extends Omit<ShadcnButtonProps, 'asChild'> {
   href: string
   internal?: boolean
   text: string
-  icon?: LucideIcon
+  children?: ReactNode
 }
 
-export const Button = ({ href, text, internal, ...props }: ButtonProps) => {
-  const content = (
-    <>
-      {text}
-      {props.icon && <props.icon className="ml-2 h-4 w-4" />}
-    </>
-  )
+export const Button = ({
+  href,
+  text,
+  internal,
+  children,
+  ...props
+}: ButtonProps) => {
+  const content = children ? (text ? <>{text} {children}</> : children) : (text && <>{text}</>)
   if (href) {
     return (
       <Link internal={internal} href={href}>

--- a/starters/remix/app/components/primitives/TeaserCard/TeaserCard.tsx
+++ b/starters/remix/app/components/primitives/TeaserCard/TeaserCard.tsx
@@ -61,13 +61,9 @@ export const TeaserCard = ({
         <p className="flex-grow text-sm text-muted-foreground">{summary}</p>
         {details && (
           <div className="pt-2">
-            <Button
-              variant="link"
-              className="p-0"
-              icon={ChevronRight}
-              internal
-              {...details}
-            />
+            <Button variant="link" className="p-0" internal {...details}>
+              <ChevronRight className="ml-2 h-4 w-4" />
+            </Button>
           </div>
         )}
       </div>

--- a/starters/storybook/app/components/primitives/Button/Button.stories.tsx
+++ b/starters/storybook/app/components/primitives/Button/Button.stories.tsx
@@ -8,9 +8,9 @@ const meta: Meta<typeof Button> = {
   tags: ['autodocs'],
   args: {
     text: 'Default',
-    icon: undefined,
     variant: 'default',
     size: 'default',
+    children: undefined,
   },
   argTypes: {
     variant: {
@@ -27,11 +27,6 @@ const meta: Meta<typeof Button> = {
     size: {
       control: 'select',
       options: ['default', 'sm', 'lg', 'icon'],
-    },
-    icon: {
-      table: {
-        disable: true,
-      },
     },
   },
 }
@@ -78,13 +73,14 @@ export const Large: Story = {
 
 export const WithIcon: Story = {
   args: {
-    icon: ChevronRight,
+    text: 'With Icon',
+    children: <ChevronRight />,
   },
 }
 
 export const IconOnly: Story = {
   args: {
     text: '',
-    icon: ChevronRight,
+    children: <ChevronRight />,
   },
 }

--- a/starters/storybook/app/components/primitives/Button/Button.tsx
+++ b/starters/storybook/app/components/primitives/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { LucideIcon } from 'lucide-react'
+import { ReactNode } from 'react'
 import { Link } from '~/components/primitives'
 import {
   Button as ShadcnButton,
@@ -9,16 +9,17 @@ export interface ButtonProps extends Omit<ShadcnButtonProps, 'asChild'> {
   href: string
   internal?: boolean
   text: string
-  icon?: LucideIcon
+  children?: ReactNode
 }
 
-export const Button = ({ href, text, internal, ...props }: ButtonProps) => {
-  const content = (
-    <>
-      {text}
-      {props.icon && <props.icon className="ml-2 h-4 w-4" />}
-    </>
-  )
+export const Button = ({
+  href,
+  text,
+  internal,
+  children,
+  ...props
+}: ButtonProps) => {
+  const content = children ? (text ? <>{text} {children}</> : children) : (text && <>{text}</>)
   if (href) {
     return (
       <Link internal={internal} href={href}>

--- a/starters/storybook/app/components/primitives/TeaserCard/TeaserCard.tsx
+++ b/starters/storybook/app/components/primitives/TeaserCard/TeaserCard.tsx
@@ -61,13 +61,9 @@ export const TeaserCard = ({
         <p className="flex-grow text-sm text-muted-foreground">{summary}</p>
         {details && (
           <div className="pt-2">
-            <Button
-              variant="link"
-              className="p-0"
-              icon={ChevronRight}
-              internal
-              {...details}
-            />
+            <Button variant="link" className="p-0" internal {...details}>
+              <ChevronRight className="ml-2 h-4 w-4" />
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
This pull request includes several changes to the `Button` component and its usage across multiple files and frameworks. The main goal is to replace the `icon` prop with a more flexible `children` prop, allowing for better customization and consistency. 

Changes to `Button` component:

* Replaced `icon` prop with `children` prop in `Button` component and updated its interface to use `ReactNode` instead of `LucideIcon`. (`starters/next/components/primitives/Button/Button.tsx`, `starters/remix/app/components/primitives/Button/Button.tsx`, `starters/storybook/app/components/primitives/Button/Button.tsx`) [[1]](diffhunk://#diff-01d88893436362cbcc37f4bd5bd303aa75d709a4ca1fb6e75da68e2f2a1cc1a3L1-R1) [[2]](diffhunk://#diff-c606f396e2f0586eb13991bee98df305b1dd1abfbd93c6d819631b257d568b84L1-R1) [[3]](diffhunk://#diff-c606f396e2f0586eb13991bee98df305b1dd1abfbd93c6d819631b257d568b84L1-R1)
* Updated the `Button` component's content rendering logic to accommodate the new `children` prop. (`starters/next/components/primitives/Button/Button.tsx`, `starters/remix/app/components/primitives/Button/Button.tsx`, `starters/storybook/app/components/primitives/Button/Button.tsx`) [[1]](diffhunk://#diff-01d88893436362cbcc37f4bd5bd303aa75d709a4ca1fb6e75da68e2f2a1cc1a3L12-R22) [[2]](diffhunk://#diff-c606f396e2f0586eb13991bee98df305b1dd1abfbd93c6d819631b257d568b84L12-R22) [[3]](diffhunk://#diff-c606f396e2f0586eb13991bee98df305b1dd1abfbd93c6d819631b257d568b84L12-R22)

Changes to Button stories:

* Removed `icon` prop and added `children` prop in storybook meta definitions. (`starters/next/components/primitives/Button/Button.stories.tsx`, `starters/remix/app/components/primitives/Button/Button.stories.tsx`, `starters/storybook/app/components/primitives/Button/Button.stories.tsx`) [[1]](diffhunk://#diff-077269b35b57b1dd9d2b59d7b511b9b5645654fc588d57525dc3f9b28c91f0d6L11-R13) [[2]](diffhunk://#diff-c1130b2856d829233e52aa7c03adb6047ce2b7bb515578f34f805e79a431f94eL11-R13) [[3]](diffhunk://#diff-c1130b2856d829233e52aa7c03adb6047ce2b7bb515578f34f805e79a431f94eL11-R13)
* Updated stories to use `children` prop instead of `icon` prop. (`starters/next/components/primitives/Button/Button.stories.tsx`, `starters/remix/app/components/primitives/Button/Button.stories.tsx`, `starters/storybook/app/components/primitives/Button/Button.stories.tsx`) [[1]](diffhunk://#diff-077269b35b57b1dd9d2b59d7b511b9b5645654fc588d57525dc3f9b28c91f0d6L81-R84) [[2]](diffhunk://#diff-c1130b2856d829233e52aa7c03adb6047ce2b7bb515578f34f805e79a431f94eL81-R84) [[3]](diffhunk://#diff-c1130b2856d829233e52aa7c03adb6047ce2b7bb515578f34f805e79a431f94eL81-R84)

Changes to `TeaserCard` component:

* Updated `TeaserCard` component to use the new `children` prop for `Button` component. (`starters/next/components/primitives/TeaserCard/TeaserCard.tsx`, `starters/remix/app/components/primitives/TeaserCard/TeaserCard.tsx`, `starters/storybook/app/components/primitives/TeaserCard/TeaserCard.tsx`) [[1]](diffhunk://#diff-32097e5a5ed243bd72f33263bf77156d9b2e8654b5ecd97040b96fc9faa32ea5L64-R66) [[2]](diffhunk://#diff-89a6547b72e26e8becda03f4e09b318e9a95fc4cfcb55a3a27f554d90c6ce8bfL64-R66) [[3]](diffhunk://#diff-89a6547b72e26e8becda03f4e09b318e9a95fc4cfcb55a3a27f554d90c6ce8bfL64-R66)