### PR TITLE
🗑️ feat: Deprecate remix starter

### DIFF
--- a/starters/remix/README.md
+++ b/starters/remix/README.md
@@ -1,5 +1,8 @@
 # Drupal Decoupled: Remix
 
+> [!WARNING] Deprecated
+This template is no longer maintained as Remix has been marked as deprecated. We recommend using the [React Router starter](https://drupal-decoupled.octahedroid.com/docs/getting-started/quick-start/react-router/) instead.
+
 ## Getting Started
 
 Visit the docs to see how to use this [Remix](https://drupal-decoupled.octahedroid.com/docs/getting-started/quickstart/remix) starter.

--- a/starters/remix/package.json
+++ b/starters/remix/package.json
@@ -1,5 +1,6 @@
 {
   "name": "graphql",
+  "deprecated": "This template is deprecated. Please use our new template instead: npx create-react-router@latest --template octahedroid/drupal-decoupled/starters/react-router",
   "private": true,
   "sideEffects": false,
   "type": "module",
@@ -15,7 +16,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "format": "prettier --check --ignore-path .gitignore --ignore-path .prettierignore  .",
-    "format:fix": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore ."
+    "format:fix": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore .",
+    "postinstall": "node ./scripts/post-install.js"
   },
   "dependencies": {
     "@conform-to/react": "^1.3.0",

--- a/starters/remix/scripts/post-install.js
+++ b/starters/remix/scripts/post-install.js
@@ -1,0 +1,13 @@
+console.log(
+  '\x1b[33m%s\x1b[0m',
+  `
+    ==================================================
+    ⚠️  DEPRECATION NOTICE ⚠️
+    
+    The Remix starter is deprecated and will no longer be maintained.
+    Please use our new React Router starter instead:
+    npx create-react-router@latest --template octahedroid/drupal-decoupled/starters/react-router
+    
+    ==================================================
+    `
+)


### PR DESCRIPTION
This pull request marks the `Remix` starter template as deprecated and introduces updates to notify users about its deprecation. Key changes include updates to documentation, package metadata, and the addition of a post-install script to display a deprecation notice.

### Deprecation Updates:

* [`starters/remix/README.md`](diffhunk://#diff-2811ac039870e757e00ce1f3f6d6cdeacca254766c2d6306bfc11ac8c737b69fR3-R5): Added a deprecation warning at the top of the README, recommending the use of the `React Router` starter instead.
* [`starters/remix/package.json`](diffhunk://#diff-387bfcfdbe39dafd51f64f9a70004f642c766ff0f6065bea5daa44dcd67327f3R3): Added a `deprecated` field with a message directing users to the new `React Router` template.
* [`starters/remix/scripts/post-install.js`](diffhunk://#diff-14ac60007d9be15da6e453445e834fcfde303c43870625a67bee9cc122fcc40fR1-R13): Introduced a post-install script that logs a prominent deprecation notice to the console.

### Build and Maintenance:

* [`starters/remix/package.json`](diffhunk://#diff-387bfcfdbe39dafd51f64f9a70004f642c766ff0f6065bea5daa44dcd67327f3L18-R20): Added a `postinstall` script entry to execute the new `post-install.js` script after dependencies are installed.