### PR TITLE
✨ feat: Add webform resolver for nextjs

### DIFF
--- a/starters/next/integration/forms/ContactForm/ContactForm.tsx
+++ b/starters/next/integration/forms/ContactForm/ContactForm.tsx
@@ -10,10 +10,10 @@ import { contactFormSchema } from '@/integration/forms/ContactForm/schema'
 import { useActionState } from 'react'
 import { submitContactFormAction } from '@/integration/forms/ContactForm/action'
 
-export const ContactForm = () => {
+export const ContactForm = ({ id }: { id: string }) => {
   const [state, action] = useActionState(submitContactFormAction, undefined)
   const [form, fields] = useForm({
-    id: 'contact-form',
+    id,
     lastResult: state?.reply,
     constraint: getZodConstraint(contactFormSchema),
     onValidate({ formData }) {

--- a/starters/next/integration/resolvers/ParagraphWebformResolver.tsx
+++ b/starters/next/integration/resolvers/ParagraphWebformResolver.tsx
@@ -26,12 +26,23 @@ export const ParagraphWebformFragment = graphql(
   [WebformFragment]
 )
 
+type FormComponents = React.FC<{ id: string }>
+
+const WebformComponentResolver: Record<string, FormComponents> = {
+  contact_form: ContactForm,
+}
+
 export const ParagraphWebformResolver = ({
   paragraph,
 }: ParagraphWebformProps) => {
   const { heading, subheadingOptional, descriptionOptional, form } =
     readFragment(ParagraphWebformFragment, paragraph)
 
+  if (!form || !form.id) {
+    return null
+  }
+
+  const Webform = WebformComponentResolver[form.id]
   return (
     <div className="container mx-auto py-8 md:py-16 lg:py-24">
       <div>
@@ -47,11 +58,9 @@ export const ParagraphWebformResolver = ({
             dangerouslySetInnerHTML={{ __html: descriptionOptional }}
           />
         )}
-        {form && (
-          <div className="py-8 md:py-16 lg:py-24">
-            <ContactForm />
-          </div>
-        )}
+        <div className="py-8 md:py-16 lg:py-24">
+          <Webform id={form.id} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and reusability of the `ContactForm` component and its integration with the `ParagraphWebformResolver`. The updates include making the `ContactForm` component more dynamic by accepting an `id` prop and implementing a resolver to map form types to their respective components.

### Changes to `ContactForm`:

* [`starters/next/integration/forms/ContactForm/ContactForm.tsx`](diffhunk://#diff-227814eff892f167bfd5175527a94bd693a2cacdfe0fdf2cf6b1a2fccac964d5L13-R16): Updated the `ContactForm` component to accept an `id` prop, making it reusable for different form instances. The `id` is now passed dynamically instead of being hardcoded.

### Integration with `ParagraphWebformResolver`:

* [`starters/next/integration/resolvers/ParagraphWebformResolver.tsx`](diffhunk://#diff-32d096f01fd0017f19318b95c64c9334c32f1d03657faeca4fa407992a19ea2cR29-R45): Introduced a `WebformComponentResolver` to map form types (e.g., `contact_form`) to their corresponding components, enabling dynamic selection of form components based on the `form.id`.
* [`starters/next/integration/resolvers/ParagraphWebformResolver.tsx`](diffhunk://#diff-32d096f01fd0017f19318b95c64c9334c32f1d03657faeca4fa407992a19ea2cL50-L54): Modified the `ParagraphWebformResolver` to use the `WebformComponentResolver` for rendering the appropriate form component dynamically. The `Webform` component is now rendered with the `id` prop passed to it.