### PR TITLE
⬆️ feat: Update drupal auth version in starters

### DIFF
--- a/packages/create-drupal-decoupled/src/templates/shared/auth.server.ts
+++ b/packages/create-drupal-decoupled/src/templates/shared/auth.server.ts
@@ -7,7 +7,7 @@ interface TokenArgs {
 }
 
 export const getToken = async ({ uri, clientId, clientSecret }: TokenArgs) => {
-  const client = await drupalAuthClient(uri, 'client_credentials', {
+  const client = await drupalAuthClient(uri, {
     clientId,
     clientSecret,
   })

--- a/starters/next/package.json
+++ b/starters/next/package.json
@@ -26,7 +26,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "composable-functions": "^5.0.0",
-    "drupal-auth-client": "^0.4",
+    "drupal-auth-client": "^1.0",
     "drupal-decoupled": "^0.2.2",
     "gql.tada": "^1.8.10",
     "lucide-react": "^0.474.0",

--- a/starters/next/scripts/sync.ts
+++ b/starters/next/scripts/sync.ts
@@ -11,14 +11,10 @@ import {
 
   dotenv.config({ path: envPath })
 
-  const authClient = await drupalAuthClient(
-    process.env.DRUPAL_AUTH_URI!,
-    'client_credentials',
-    {
-      clientId: process.env.DRUPAL_CLIENT_ID!,
-      clientSecret: process.env.DRUPAL_CLIENT_SECRET!,
-    }
-  )
+  const authClient = await drupalAuthClient(process.env.DRUPAL_AUTH_URI!, {
+    clientId: process.env.DRUPAL_CLIENT_ID!,
+    clientSecret: process.env.DRUPAL_CLIENT_SECRET!,
+  })
 
   console.log('\n🚀 Generating GraphQL Schema')
   await generateSchema({

--- a/starters/next/utils/auth.ts
+++ b/starters/next/utils/auth.ts
@@ -7,7 +7,7 @@ interface TokenArgs {
 }
 
 export const getToken = async ({ uri, clientId, clientSecret }: TokenArgs) => {
-  const client = await drupalAuthClient(uri, 'client_credentials', {
+  const client = await drupalAuthClient(uri, {
     clientId,
     clientSecret,
   })

--- a/starters/next/yarn.lock
+++ b/starters/next/yarn.lock
@@ -3932,10 +3932,10 @@ dotenv@^16.4.5:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
-drupal-auth-client@^0.4:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/drupal-auth-client/-/drupal-auth-client-0.4.0.tgz#1ecec93b3404744546291e6e4f25ddb7b536b536"
-  integrity sha512-isCGyIQazg9Mi+zF/b96wSZ4R4U9mxayHPejvNQqkp/GolxkJ/vkrvxTcU3ShLrk3CkspPYPfr6uGEzyW2F5Rw==
+drupal-auth-client@^1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/drupal-auth-client/-/drupal-auth-client-1.0.0.tgz#792d00c1c38ff0cab8987e408632cecb5f5c1ed3"
+  integrity sha512-RLsh0J5sCGbgMbkOwpUkGreM6StIgfTUcYtsnbIIV2r/0Y8HlrXPRY1e9x7SKnHH5hwDmpzhJ1YZen4cOHGdlw==
 
 drupal-decoupled@^0.2.2:
   version "0.2.2"

--- a/starters/react-router/app/utils/auth.server.ts
+++ b/starters/react-router/app/utils/auth.server.ts
@@ -7,7 +7,7 @@ interface TokenArgs {
 }
 
 export const getToken = async ({ uri, clientId, clientSecret }: TokenArgs) => {
-  const client = await drupalAuthClient(uri, 'client_credentials', {
+  const client = await drupalAuthClient(uri, {
     clientId,
     clientSecret,
   })

--- a/starters/react-router/package.json
+++ b/starters/react-router/package.json
@@ -28,7 +28,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "composable-functions": "^5.0.0",
-    "drupal-auth-client": "^0.4",
+    "drupal-auth-client": "^1.0",
     "drupal-decoupled": "^0.2.2",
     "gql.tada": "^1.8.10",
     "isbot": "^5.1.17",

--- a/starters/react-router/scripts/sync.ts
+++ b/starters/react-router/scripts/sync.ts
@@ -10,14 +10,10 @@ import {
   const envPath = path.join(process.cwd(), '.env')
   dotenv.config({ path: envPath })
 
-  const authClient = await drupalAuthClient(
-    process.env.DRUPAL_AUTH_URI!,
-    'client_credentials',
-    {
-      clientId: process.env.DRUPAL_CLIENT_ID!,
-      clientSecret: process.env.DRUPAL_CLIENT_SECRET!,
-    }
-  )
+  const authClient = await drupalAuthClient(process.env.DRUPAL_AUTH_URI!, {
+    clientId: process.env.DRUPAL_CLIENT_ID!,
+    clientSecret: process.env.DRUPAL_CLIENT_SECRET!,
+  })
 
   console.log('\n🚀 Generating GraphQL Schema')
   await generateSchema({

--- a/starters/react-router/yarn.lock
+++ b/starters/react-router/yarn.lock
@@ -2397,10 +2397,10 @@ dom-accessibility-api@^0.6.3:
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
   integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
-drupal-auth-client@^0.4:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/drupal-auth-client/-/drupal-auth-client-0.4.0.tgz#1ecec93b3404744546291e6e4f25ddb7b536b536"
-  integrity sha512-isCGyIQazg9Mi+zF/b96wSZ4R4U9mxayHPejvNQqkp/GolxkJ/vkrvxTcU3ShLrk3CkspPYPfr6uGEzyW2F5Rw==
+drupal-auth-client@^1.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/drupal-auth-client/-/drupal-auth-client-1.0.0.tgz#792d00c1c38ff0cab8987e408632cecb5f5c1ed3"
+  integrity sha512-RLsh0J5sCGbgMbkOwpUkGreM6StIgfTUcYtsnbIIV2r/0Y8HlrXPRY1e9x7SKnHH5hwDmpzhJ1YZen4cOHGdlw==
 
 drupal-decoupled@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
This pull request updates the `drupal-auth-client` package to version `1.0` and refactors the `getToken` function across multiple files to align with the updated API. These changes ensure compatibility with the new version of the package and simplify the function's implementation.

### Dependency Updates:
* Updated the `drupal-auth-client` dependency from `^0.4` to `^1.0` in `starters/next/package.json` and `starters/react-router/package.json`. [[1]](diffhunk://#diff-dfefee002f5f0015245ab3986a12033fc3853eb0c3773aca991267844da78e78L29-R29) [[2]](diffhunk://#diff-3fc03ee556c740f39a303139a1672ed49005bab9e03cf00c576838e3ba47c409L31-R31)

### Code Refactoring:
* Refactored the `getToken` function in `auth.server.ts` (both in `packages/create-drupal-decoupled/src/templates/shared/` and `starters/react-router/app/utils/`) and `auth.ts` in `starters/next/utils/` to remove the `client_credentials` parameter when calling `drupalAuthClient`, as it is no longer required with the updated package.