### PR TITLE
🔖 feat: Update create drupal decoupled version

### DIFF
--- a/packages/create-drupal-decoupled/package.json
+++ b/packages/create-drupal-decoupled/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octahedroid/create-drupal-decoupled",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "packageManager": "yarn@1.22.22",
   "description": "Scaffold the integration with Drupal in a decoupled frontend",
   "keywords": [


### PR DESCRIPTION
This pull request includes a version bump for the `@octahedroid/create-drupal-decoupled` package. The version has been updated from `0.5.0` to `0.5.1` in the `package.json` file to reflect a new release.