### PR TITLE
Update Quickstart link in starters

### DIFF
--- a/starters/next/app/[[...slug]]/page.tsx
+++ b/starters/next/app/[[...slug]]/page.tsx
@@ -110,7 +110,7 @@ async function getDrupalData({ params }: { params: { slug: string[] } }) {
         },
         {
           text: 'Quickstart',
-          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quickstart',
+          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quick-start/drupal',
         },
       ],
     },

--- a/starters/react-router/app/routes/$.tsx
+++ b/starters/react-router/app/routes/$.tsx
@@ -138,7 +138,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
         },
         {
           text: 'Quickstart',
-          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quickstart',
+          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quick-start/drupal',
         },
       ],
     },

--- a/starters/remix/app/routes/$.tsx
+++ b/starters/remix/app/routes/$.tsx
@@ -147,7 +147,7 @@ export const loader = async ({
         },
         {
           text: 'Quickstart',
-          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quickstart',
+          href: 'https://drupal-decoupled.octahedroid.com/docs/getting-started/quick-start/drupal',
         },
       ],
     },


### PR DESCRIPTION
Update the Quickstart link across multiple starter files to point to the correct URL. This change ensures users access the appropriate documentation for getting started.

| File Path                                      | Change Description                          |
|------------------------------------------------|--------------------------------------------|
| 🐛 `starters/next/app/[[...slug]]/page.tsx`   | Updated Quickstart link                    |
| 🐛 `starters/react-router/app/routes/$.tsx`    | Updated Quickstart link                    |
| 🐛 `starters/remix/app/routes/$.tsx`           | Updated Quickstart link                    |
