### PR TITLE
✨ feat: Use shadcn prose in starters

### DIFF
--- a/starters/next/app/globals.css
+++ b/starters/next/app/globals.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 @import 'tw-animate-css';
-@plugin '@tailwindcss/typography';
+@import 'shadcn-prose';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/starters/next/package.json
+++ b/starters/next/package.json
@@ -33,6 +33,7 @@
     "next": "15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "shadcn-prose": "^1.0.8",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"
   },

--- a/starters/next/yarn.lock
+++ b/starters/next/yarn.lock
@@ -6840,6 +6840,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+shadcn-prose@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/shadcn-prose/-/shadcn-prose-1.0.8.tgz#4a49988a877098490fa95fccf2a0f7be29cf66cd"
+  integrity sha512-Llpz/dC+ZTqLzh8qrIZM5p5ggbHQ4MKP90NkfXvV1CF5Hdg8uFO+IAiF1P5mSqMHqnPW0XT9ZkqqgXR7fNSVig==
+
 sharp@^0.33.3:
   version "0.33.5"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.33.5.tgz#13e0e4130cc309d6a9497596715240b2ec0c594e"

--- a/starters/react-router/app/app.css
+++ b/starters/react-router/app/app.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 @import 'tw-animate-css';
-@plugin '@tailwindcss/typography';
+@import 'shadcn-prose';
 
 @custom-variant dark (&:is(.dark *));
 

--- a/starters/react-router/package.json
+++ b/starters/react-router/package.json
@@ -37,6 +37,7 @@
     "react-dom": "^19.1.0",
     "react-router": "^7.5.0",
     "remix-utils": "^8.5.0",
+    "shadcn-prose": "^1.0.8",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.24.2"
   },

--- a/starters/react-router/yarn.lock
+++ b/starters/react-router/yarn.lock
@@ -4745,6 +4745,11 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shadcn-prose@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/shadcn-prose/-/shadcn-prose-1.0.8.tgz#4a49988a877098490fa95fccf2a0f7be29cf66cd"
+  integrity sha512-Llpz/dC+ZTqLzh8qrIZM5p5ggbHQ4MKP90NkfXvV1CF5Hdg8uFO+IAiF1P5mSqMHqnPW0XT9ZkqqgXR7fNSVig==
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"


### PR DESCRIPTION
This pull request updates the styling approach in two starter projects (`next` and `react-router`) by replacing the `@tailwindcss/typography` plugin with the `shadcn-prose` package. Corresponding dependencies have been added to the `package.json` files of both projects.

Styling updates:

* [`starters/next/app/globals.css`](diffhunk://#diff-078878244f37a1c210985ea2babb6a8e7912233c6f180d43931fe7488289a332L4-R4): Replaced `@plugin '@tailwindcss/typography'` with `@import 'shadcn-prose'` to update the typography styling approach.
* [`starters/react-router/app/app.css`](diffhunk://#diff-6f871889abe5b3f188249a93e8900e9fa1e9cebac9c7e7fd5e9c32f1d865ddd4L4-R4): Replaced `@plugin '@tailwindcss/typography'` with `@import 'shadcn-prose'` to align with the updated typography styling.

Dependency updates:

* [`starters/next/package.json`](diffhunk://#diff-dfefee002f5f0015245ab3986a12033fc3853eb0c3773aca991267844da78e78R36): Added `shadcn-prose` version `^1.0.8` as a dependency.
* [`starters/react-router/package.json`](diffhunk://#diff-3fc03ee556c740f39a303139a1672ed49005bab9e03cf00c576838e3ba47c409R40): Added `shadcn-prose` version `^1.0.8` as a dependency.