### PR TITLE
🔥 fix: Update package json

### DIFF
--- a/packages/drupal-vite/package.json
+++ b/packages/drupal-vite/package.json
@@ -56,8 +56,7 @@
   "dependencies": {
     "@types/fs-extra": "^11.0.4",
     "drupal-auth-client": "^1.0.2",
-    "fs-extra": "^11.3.0",
-    "jiti": "^2.5.1"
+    "fs-extra": "^11.3.0"
   },
   "keywords": [
     "vite-plugin",


### PR DESCRIPTION
This pull request makes a minor update to the `packages/drupal-vite/package.json` dependencies by removing the unused `jiti` package. This helps keep the dependency list clean and reduces potential security or maintenance overhead.

- Dependency cleanup:
  * Removed the `jiti` package from the dependencies in `package.json`, as it is no longer needed.